### PR TITLE
debug: fix obs key for CubeTask

### DIFF
--- a/gym_genesis/tasks/cube.py
+++ b/gym_genesis/tasks/cube.py
@@ -121,7 +121,7 @@ class CubeTask:
         ])
         if self.enable_pixels:
             return {
-                "agent_pos": state.astype(np.float32),
+                "state": state.astype(np.float32),
                 "pixels": self.cam.render()[0] # since render always return a tuple
             }
 


### PR DESCRIPTION
Running `examples/pick-cube.py` resulted in `KeyError: state`. I guess this should fix that :)
